### PR TITLE
Feature/views part 2

### DIFF
--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -8,66 +8,11 @@ API class representing a cloudant database
 import json
 import posixpath
 import urllib
-import requests
-from collections import Sequence
 
 from .document import CloudantDocument
 from .views import DesignDocument
 from .errors import CloudantException
-from .utils import python_to_couch, ALL_ARGS
-
-
-
-class PrimaryIndex(object):
-    """
-    _PrimaryIndex_
-
-    Slice/dict like access helper to the _all_docs endpoint
-    for a given database
-
-    """
-    def __init__(self, database):
-        self._database = database
-        self._r_session = database._r_session
-
-    def __getitem__(self, key):
-        if isinstance(key, basestring):
-            data = self._database.all_docs(key=key)
-            return data['rows']
-
-        if isinstance(key, Sequence):
-            data = self._database.all_docs(key=key)
-            return data['rows']
-
-        if isinstance(key, slice):
-            str_or_none_start = isinstance(key.start, (basestring, list)) or key.start is None
-            str_or_none_stop =  isinstance(key.stop, (basestring, list)) or key.stop is None
-            if str_or_none_start and str_or_none_stop:
-                # startkey/endkey
-                if key.stop is None and key.start is not None:
-                    data = self._database.all_docs(startkey=key.start)
-                if key.start is None and key.stop is not None:
-                    data = self._database.all_docs(endkey=key.stop)
-                if key.start is None and key.stop is None:
-                    data = self._database.all_docs()
-                if key.start is not None and key.stop is not None:
-                    data = self._database.all_docs(startkey=key.start, endkey=key.stop)
-                return data['rows']
-            int_or_none_start = isinstance(key.start, (int)) or key.start is None
-            int_or_none_stop = isinstance(key.stop, (int)) or key.stop is None
-            if int_or_none_start and int_or_none_stop:
-                if key.start is not None and key.stop is not None:
-                    data = self._database.all_docs(skip=key.start, limit=key.stop)
-                if key.start is not None and key.stop is None:
-                    data = self._database.all_docs(skip=key.start)
-                if key.start is None and key.stop is not None:
-                    data = self._database.all_docs(limit=key.stop)
-                if key.start is None and key.stop is None:
-                    data = self._database.all_docs()
-                data = self._database.all_docs(skip=key.start, limit=key.stop)
-                return data['rows']
-
-        raise RuntimeError("wtf is {0}?".format(key))
+from .index import python_to_couch, ALL_ARGS, Index
 
 
 class CloudantDatabase(dict):
@@ -82,7 +27,7 @@ class CloudantDatabase(dict):
         self._database_name = database_name
         self._r_session = cloudant._r_session
         self._fetch_limit = fetch_limit
-        self.index = PrimaryIndex(self)
+        self.index = Index(self.all_docs)
 
     @property
     def database_url(self):

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -140,14 +140,22 @@ class CloudantDatabase(dict):
 
     def all_docs(self, **kwargs):
         """
+        TODO: docstring worth a damn
 
-        descending  Return the documents in descending by key order boolean false
-        endkey  Stop returning records when the specified key is reached string
-        include_docs    Include the full content of the documents in the return boolean false
-        inclusive_end   Include rows whose key equals the endkey  boolean true
-        key Return only documents that match the specified key  string
-        limit   Limit the number of the returned documents to the specified number  numeric
-        skip    Skip this number of records before starting to return the results  numeric 0
+        descending  Return the documents in descending by key
+            order boolean false
+        endkey  Stop returning records when the specified key is
+            reached string
+        include_docs    Include the full content of the documents
+            in the return boolean false
+        inclusive_end   Include rows whose key equals the endkey
+            boolean true
+        key Return only documents that match the
+            specified key  string
+        limit   Limit the number of the returned documents
+            to the specified number  numeric
+        skip    Skip this number of records before starting to
+           return the results  numeric 0
         startkey
 
         """
@@ -155,7 +163,13 @@ class CloudantDatabase(dict):
             if k not in ALL_ARGS:
                 raise ValueError("Invalid argument: {0}".format(k))
         params = python_to_couch(kwargs)
-        resp = self._r_session.get(posixpath.join(self.database_url, '_all_docs'), params=params)
+        resp = self._r_session.get(
+            posixpath.join(
+                self.database_url,
+                '_all_docs'
+            ),
+            params=params
+        )
         data = resp.json()
         return data
 
@@ -167,7 +181,7 @@ class CloudantDatabase(dict):
         if not remote:
             return super(CloudantDatabase, self).keys()
         docs = self.all_docs()
-        return [ row['id'] for row in docs.get('rows', []) ]
+        return [row['id'] for row in docs.get('rows', [])]
 
     def changes(self, since=None, continuous=True):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -12,7 +12,7 @@ import urllib
 from .document import CloudantDocument
 from .views import DesignDocument
 from .errors import CloudantException
-from .index import python_to_couch, ALL_ARGS, Index
+from .index import python_to_couch, Index
 
 
 class CloudantDatabase(dict):
@@ -159,9 +159,6 @@ class CloudantDatabase(dict):
         startkey
 
         """
-        for k in kwargs:
-            if k not in ALL_ARGS:
-                raise ValueError("Invalid argument: {0}".format(k))
         params = python_to_couch(kwargs)
         resp = self._r_session.get(
             posixpath.join(

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""
+_utils_
+
+General utilities
+
+
+"""
+import json
+
+from collections import Sequence
+
+ALL_ARGS = [
+    "descending",
+    "endkey",
+    "endkey_docid",
+    "group",
+    "group_level",
+    "include_docs",
+    "inclusive_end",
+    "key",
+    "limit",
+    "reduce",
+    "skip",
+    "stale",
+    "startkey",
+    "startkey_docid"
+]
+
+BOOLEAN_ARGS = [
+    'include_docs',
+    'inclusive_end',
+    'reduce',
+    'group',
+    'descending'
+]
+
+ARRAY_ARGS = [
+    'startkey',
+    'endkey'
+]
+STRING_ARGS = [
+    'key',
+]
+
+
+def python_to_couch(kwargs):
+    """
+    _python_to_couch_
+
+    Translator method to flip python style
+    options into couch query options, eg True => 'true'
+    """
+    for b in BOOLEAN_ARGS:
+        if b in kwargs:
+            if kwargs[b]:
+                kwargs[b] = 'true'
+            else:
+                kwargs[b] = 'false'
+    for a in ARRAY_ARGS:
+        if a in kwargs:
+            value = kwargs[a]
+            if isinstance(value, Sequence):
+                kwargs[a] = json.dumps(list(value))
+            elif isinstance(value, basestring):
+                kwargs[a] = json.dumps(value)
+    for s in STRING_ARGS:
+        if s in kwargs:
+            kwargs[s] = json.dumps(kwargs[s])
+    return kwargs
+
+
+class Index(object):
+    """
+    _Index_
+
+    Sliceable and iterable interface to CouchDB View like things
+
+    """
+    def __init__(self, method_ref, **options):
+        self.options = options
+        self._ref = method_ref
+        self._page_size = options.pop("page_size", 100)
+        self._valid_args = ALL_ARGS
+
+    def _prepare_extras(self):
+        """
+        check that extra params are expected/valid
+        """
+        for k in self.options:
+            if k not in self._valid_args:
+                raise ValueError("Invalid argument: {0}".format(k))
+        extras = python_to_couch(self.options)
+        return extras
+
+
+    def __getitem__(self, key):
+        """
+        implement key access and slicing
+
+
+        """
+        extras = self._prepare_extras()
+        if isinstance(key, basestring):
+            data = self._ref(key=key, **extras)
+            return data['rows']
+
+        if isinstance(key, list):
+            data = self._ref(key=key, **extras)
+            return data['rows']
+
+        if isinstance(key, slice):
+            # slice is startkey and endkey if str or array
+            str_or_none_start = isinstance(key.start, (basestring, list)) or key.start is None
+            str_or_none_stop =  isinstance(key.stop, (basestring, list)) or key.stop is None
+            if str_or_none_start and str_or_none_stop:
+                # startkey/endkey
+                if key.start is not None and key.stop is not None:
+                    data = self._ref(startkey=key.start, endkey=key.stop)
+                if key.start is not None and key.stop is None:
+                    data = self._ref(startkey=key.start)
+                if key.start is None and key.stop is not None:
+                    data = self._ref(endkey=key.stop)
+                if key.start is None and key.stop is None:
+                    data = self._ref()
+                return data['rows']
+            # slice is skip:limit if ints
+            int_or_none_start = isinstance(key.start, (int)) or key.start is None
+            int_or_none_stop = isinstance(key.stop, (int)) or key.stop is None
+            if int_or_none_start and int_or_none_stop:
+                if key.start is not None and key.stop is not None:
+                    data = self._ref(skip=key.start, limit=key.stop)
+                if key.start is not None and key.stop is None:
+                    data = self._ref(skip=key.start)
+                if key.start is None and key.stop is not None:
+                    data = self._ref(limit=key.stop)
+                # both None case handled above
+                return data['rows']
+
+        raise RuntimeError("wtf was {0}??".format(key))
+
+
+    def __iter__(self):
+        """
+        Implement iteration protocol by calling the
+        data method accessor and paging through the responses
+
+        Custom iteration ranges can be controlled via the ctor options
+
+        """
+        #TODO custom options need to be converted to couch friendly things
+        #     eg if iteration by page is between a start key and end key
+        #     verify that paging between startkey/endkey and integer indexes works
+
+
+

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -74,7 +74,13 @@ class Index(object):
     """
     _Index_
 
-    Sliceable and iterable interface to CouchDB View like things
+    Sliceable and iterable interface to CouchDB View like things.
+
+    Instantiated with the raw data callable such as the
+    CloudantDatabase.all_docs or View.__call__ reference used to
+    retrieve data, the index can also store optional extra agrs for
+    customisation and supports efficient, paged iteration over the
+    results to avoid large views blowing up memory
 
     """
     def __init__(self, method_ref, **options):
@@ -93,11 +99,9 @@ class Index(object):
         extras = python_to_couch(self.options)
         return extras
 
-
     def __getitem__(self, key):
         """
         implement key access and slicing
-
 
         """
         extras = self._prepare_extras()
@@ -111,34 +115,48 @@ class Index(object):
 
         if isinstance(key, slice):
             # slice is startkey and endkey if str or array
-            str_or_none_start = isinstance(key.start, (basestring, list)) or key.start is None
-            str_or_none_stop =  isinstance(key.stop, (basestring, list)) or key.stop is None
+            str_or_none_start = isinstance(
+                key.start, (basestring, list)
+                ) or key.start is None
+            str_or_none_stop = isinstance(
+                key.stop, (basestring, list)
+                ) or key.stop is None
             if str_or_none_start and str_or_none_stop:
                 # startkey/endkey
                 if key.start is not None and key.stop is not None:
-                    data = self._ref(startkey=key.start, endkey=key.stop)
+                    data = self._ref(
+                        startkey=key.start,
+                        endkey=key.stop,
+                        **extras
+                    )
                 if key.start is not None and key.stop is None:
-                    data = self._ref(startkey=key.start)
+                    data = self._ref(startkey=key.start, **extras)
                 if key.start is None and key.stop is not None:
-                    data = self._ref(endkey=key.stop)
+                    data = self._ref(endkey=key.stop, **extras)
                 if key.start is None and key.stop is None:
-                    data = self._ref()
+                    data = self._ref(**extras)
                 return data['rows']
             # slice is skip:limit if ints
-            int_or_none_start = isinstance(key.start, (int)) or key.start is None
-            int_or_none_stop = isinstance(key.stop, (int)) or key.stop is None
+            int_or_none_start = isinstance(
+                key.start, (int)
+                ) or key.start is None
+            int_or_none_stop = isinstance(
+                key.stop, (int)
+                ) or key.stop is None
             if int_or_none_start and int_or_none_stop:
                 if key.start is not None and key.stop is not None:
-                    data = self._ref(skip=key.start, limit=key.stop)
+                    data = self._ref(
+                        skip=key.start,
+                        limit=key.stop,
+                        **extras
+                    )
                 if key.start is not None and key.stop is None:
-                    data = self._ref(skip=key.start)
+                    data = self._ref(skip=key.start, **extras)
                 if key.start is None and key.stop is not None:
-                    data = self._ref(limit=key.stop)
+                    data = self._ref(limit=key.stop, **extras)
                 # both None case handled above
                 return data['rows']
-
         raise RuntimeError("wtf was {0}??".format(key))
-
 
     def __iter__(self):
         """
@@ -148,9 +166,8 @@ class Index(object):
         Custom iteration ranges can be controlled via the ctor options
 
         """
-        #TODO custom options need to be converted to couch friendly things
+        # TODO custom options need to be converted to couch friendly things
         #     eg if iteration by page is between a start key and end key
-        #     verify that paging between startkey/endkey and integer indexes works
-
-
-
+        #     verify that paging between startkey/endkey and integer
+        #     indexes works
+        # ALSO: Implement this

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -9,7 +9,7 @@ import contextlib
 import posixpath
 
 from .document import CloudantDocument
-from .index import Index, ALL_ARGS, python_to_couch
+from .index import Index, python_to_couch
 
 
 class Code(str):
@@ -119,9 +119,6 @@ class View(dict):
         startkey_docid  string
 
         """
-        for k in kwargs:
-            if k not in ALL_ARGS:
-                raise ValueError("Invalid argument: {0}".format(k))
         params = python_to_couch(kwargs)
         resp = self._r_session.get(self.url, params=params)
         resp.raise_for_status()

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -124,7 +124,6 @@ class View(dict):
                 raise ValueError("Invalid argument: {0}".format(k))
         params = python_to_couch(kwargs)
         resp = self._r_session.get(self.url, params=params)
-        print ">>>>>",resp.status_code, resp.text
         resp.raise_for_status()
         return resp.json()
 
@@ -228,7 +227,7 @@ class DesignDocument(CloudantDocument):
 
         GET databasename/_design/test/_info
         """
-        pass
+        raise NotImplemented("info not yet implemented")
 
     def cleanup(self):
         """
@@ -236,10 +235,10 @@ class DesignDocument(CloudantDocument):
         POST /some_database/_view_cleanup
 
         """
-        pass
+        raise NotImplemented("cleanup not yet implemented")
 
     def compact(self):
         """
         POST /some_database/_compact/designname
         """
-        pass
+        raise NotImplemented("compact not yet implemented")

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -36,8 +36,9 @@ class View(dict):
     functions as attributes and supporting query/data access via the view
 
     """
-    def __init__(self, view_name, map_func=None, reduce_func=None):
+    def __init__(self, ddoc, view_name, map_func=None, reduce_func=None):
         super(View, self).__init__()
+        self.design_doc = ddoc
         self.view_name = view_name
         self[self.view_name] = {}
         self[self.view_name]['map'] = _codify(map_func)
@@ -93,7 +94,7 @@ class DesignDocument(CloudantDocument):
         :param map_func: str or Code object containing js map function
         :param reduce_func: str or Code object containing js reduce function
         """
-        v = View(view_name, map_func, reduce_func)
+        v = View(self, view_name, map_func, reduce_func)
         self.views[view_name] = v
         # TODO - save doc to db
 
@@ -107,6 +108,7 @@ class DesignDocument(CloudantDocument):
         super(DesignDocument, self).fetch()
         for view_name, view_def in self.get('views', {}).iteritems():
             self['views'][view_name] = View(
+                self,
                 view_name,
                 view_def.get('map'),
                 view_def.get('reduce')

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -5,6 +5,10 @@ _views_
 Utilities for handling design docs and the resulting views they create
 
 """
+from collections import Sequence
+import json
+import posixpath
+
 from .document import CloudantDocument
 
 
@@ -30,6 +34,66 @@ def _codify(code_or_str):
     return code_or_str
 
 
+ALL_ARGS = [
+    "descending",
+    "endkey",
+    "endkey_docid",
+    "group",
+    "group_level",
+    "include_docs",
+    "inclusive_end",
+    "key",
+    "limit",
+    "reduce",
+    "skip",
+    "stale",
+    "startkey",
+    "startkey_docid"
+]
+
+BOOLEAN_ARGS = [
+    'include_docs',
+    'inclusive_end',
+    'reduce',
+    'group',
+    'descending'
+]
+
+ARRAY_ARGS = [
+    'startkey',
+    'endkey'
+]
+STRING_ARGS = [
+    'key',
+]
+
+
+def python_to_couch(kwargs):
+    """
+    _python_to_couch_
+
+    Translator method to flip python style
+    options into couch query options, eg True => 'true'
+    """
+    for b in BOOLEAN_ARGS:
+        if b in kwargs:
+            if kwargs[b]:
+                kwargs[b] = 'true'
+            else:
+                kwargs[b] = 'false'
+    for a in ARRAY_ARGS:
+        if a in kwargs:
+            value = kwargs[a]
+            if isinstance(value, Sequence):
+                kwargs[a] = json.dumps(list(value))
+            elif isinstance(value, basestring):
+                kwargs[a] = json.dumps(value)
+    for s in STRING_ARGS:
+        if s in kwargs:
+            kwargs[s] = json.dumps(kwargs[s])
+    return kwargs
+
+
 class View(dict):
     """
     Dictionary based object representing a view, exposing the map, reduce
@@ -39,6 +103,7 @@ class View(dict):
     def __init__(self, ddoc, view_name, map_func=None, reduce_func=None):
         super(View, self).__init__()
         self.design_doc = ddoc
+        self._r_session = self.design_doc._r_session
         self.view_name = view_name
         self[self.view_name] = {}
         self[self.view_name]['map'] = _codify(map_func)
@@ -65,6 +130,68 @@ class View(dict):
         """reduce property setter, accepts str or Code obj"""
         f = _codify(js_func)
         self[self.view_name]['reduce'] = f
+
+    @property
+    def url(self):
+        return posixpath.join(self.design_doc._document_url, '_view', self.view_name)
+
+    def __getitem__(self, key):
+        if key == self.view_name:
+            # behave like a normal dict for only dict like key
+            return super(View, self).__getitem__(self.view_name)
+
+        if isinstance(key, basestring):
+            data = self(key=key)
+            return data['rows']
+
+        if isinstance(key, list):
+            data = self(key=key)
+            return data['rows']
+
+        if isinstance(key, slice):
+            # slice is startkey and endkey if str or array
+            str_or_none_start = isinstance(key.start, (basestring, list)) or key.start is None
+            str_or_none_stop =  isinstance(key.stop, (basestring, list)) or key.stop is None
+            if str_or_none_start and str_or_none_stop:
+                # startkey/endkey
+                data = self(startkey=key.start, endkey=key.stop)
+                return data['rows']
+            if isinstance(key.start, (int)) and isinstance(key.stop, (int)):
+                data = self(skip=key.start, limit=key.stop)
+                return data['rows']
+
+        raise RuntimeError("wtf was {0}??".format(key))
+
+
+
+    def __call__(self, **kwargs):
+        """
+        retrieve data from the view, using the kwargs provided
+        as query parameters
+
+        descending bool
+        endkey string or array
+        endkey_docid  string
+        group bool
+        group_level ??
+        include_docs bool
+        inclusive_end  bool
+        key string
+        limit   int
+        reduce  boolean
+        skip    int
+        stale   enum(ok, update_after)
+        startkey  string or array
+        startkey_docid  string
+
+        """
+        for k in kwargs:
+            if k not in ALL_ARGS:
+                raise ValueError("Invalid argument: {0}".format(k))
+        params = python_to_couch(kwargs)
+        resp = self._r_session.get(self.url, params=params)
+        resp.raise_for_status()
+        return resp.json()
 
 
 class DesignDocument(CloudantDocument):
@@ -96,7 +223,7 @@ class DesignDocument(CloudantDocument):
         """
         v = View(self, view_name, map_func, reduce_func)
         self.views[view_name] = v
-        # TODO - save doc to db
+        self.save()
 
     def fetch(self):
         """
@@ -123,3 +250,42 @@ class DesignDocument(CloudantDocument):
         """
         for view_name, view in self.views.iteritems():
             yield view_name, view
+
+    def list_views(self):
+        """
+        _views_
+
+        return a list of available views on this design doc
+        """
+        return self.views.keys()
+
+    def get_view(self, view_name):
+        """
+        _get_view_
+
+        Get a specific view by name.
+
+        """
+        return self.views.get(view_name)
+
+    def info(self):
+        """
+        retrieve the view info data, returns dictionary
+
+        GET databasename/_design/test/_info
+        """
+        pass
+
+    def cleanup(self):
+        """
+
+        POST /some_database/_view_cleanup
+
+        """
+        pass
+
+    def compact(self):
+        """
+        POST /some_database/_compact/designname
+        """
+        pass

--- a/tests/unit/cloudant_t/views_test.py
+++ b/tests/unit/cloudant_t/views_test.py
@@ -48,6 +48,25 @@ class ViewTests(unittest.TestCase):
         view5.reduce = self.reduce_func
         self.assertEqual(view5.reduce, Code(self.reduce_func))
 
+    def test_view_access(self):
+        """
+        _test_view_access_
+
+        Test accessing the data via the view
+
+        """
+        db = mock.Mock()
+        db._database_name = 'unittest'
+        ddoc = DesignDocument(db, "_design/tests")
+        ddoc._database_host = "https://bob.cloudant.com"
+        view1 = View(ddoc, "view1", map_func=self.map_func)
+
+        self.assertEqual(
+            view1.url,
+            "https://bob.cloudant.com/unittest/_design/tests/_view/view1"
+        )
+
+
 class DesignDocTests(unittest.TestCase):
     """
     tests for design doc object

--- a/tests/unit/cloudant_t/views_test.py
+++ b/tests/unit/cloudant_t/views_test.py
@@ -25,10 +25,11 @@ class ViewTests(unittest.TestCase):
 
     def test_view_class(self):
         """test various methods of instantiation and properties"""
-        view1 = View("view1", map_func=self.map_func, reduce_func=self.reduce_func)
-        view2 = View("view2", map_func=self.map_func)
-        view3 = View("view1", map_func=Code(self.map_func), reduce_func=Code(self.reduce_func))
-        view4 = View("view1", map_func=Code(self.map_func))
+        ddoc = DesignDocument(mock.Mock(), "_design/tests")
+        view1 = View(ddoc, "view1", map_func=self.map_func, reduce_func=self.reduce_func)
+        view2 = View(ddoc, "view2", map_func=self.map_func)
+        view3 = View(ddoc, "view1", map_func=Code(self.map_func), reduce_func=Code(self.reduce_func))
+        view4 = View(ddoc, "view1", map_func=Code(self.map_func))
 
         self.assertEqual(view1.map, Code(self.map_func))
         self.assertEqual(view1.reduce, Code(self.reduce_func))
@@ -39,7 +40,7 @@ class ViewTests(unittest.TestCase):
         self.assertEqual(view4.map, Code(self.map_func))
         self.assertEqual(view4.reduce, None)
 
-        view5 = View("view5")
+        view5 = View(ddoc, "view5")
         self.assertEqual(view5.map, None)
         self.assertEqual(view5.reduce, None)
         view5.map = self.map_func


### PR DESCRIPTION
@ksnavely @petevg @jcounts @dmannarino 

In this PR I add a python friendly way to get data from views via an index object on the classes that support them (Database and Views). 
This allows the user to access the view using python style slices and keys via the [] operator without colliding with the dictionary like nature of the underlying instances. 
Custom indexes with extra parameters are made available via a custom_index context manager. 

Examples of accessing data by views with this API:

```python
with cloudant('evansde77', 'HiRobNewsom') as c:
    database = c['towed_vehicles']
    ddoc = database['_design/by_date']
    view = ddoc.get_view('year_month')
    print view.index[ ["2013","10"]:["2013","11"] ]
    print view.index[100:200]
    print view.index[:200]
    print view.index[["2013","10"]]
    print view.index[["2013","10"]:]
    with view.custom_index(include_docs=True) as indx:
        print indx[100:200]
    print ">>>"
    print database.index[10:200]
    print database.index[:200]
    print database.index[10:]
    print database.index['006757A1-0D05-4919-99D4-D2C70DBFCDAD':]
    print database.index['006757A1-0D05-4919-99D4-D2C70DBFCDAD':'00251146-1A8C-4C20-9039-9CD790B50399']
    print database.index[:'00251146-1A8C-4C20-9039-9CD790B50399']

```
