### PR TITLE
downgrade requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.3.0
+requests>=2.0.1
 mock


### PR DESCRIPTION
@evansde77 @ksnavely 

I'd like to downgrade to requests 2.0.1

Running into this issue with current version:

/Users/jordancounts/git/metson/venv/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jordancounts/git/metson/src/cloudant/account.py", line 59, in connect
    self.session_login(self._cloudant_user, self._cloudant_token)
  File "/Users/jordancounts/git/metson/src/cloudant/account.py", line 114, in session_login
    resp.raise_for_status()
  File "/Users/jordancounts/git/metson/venv/lib/python2.7/site-packages/requests/models.py", line 834, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized